### PR TITLE
add etcd container for testing

### DIFF
--- a/elb/config.lua
+++ b/elb/config.lua
@@ -1,7 +1,18 @@
 local _M = {}
 
+local function get_etcd()
+    local etcd_url = os.getenv("ETCD_URL") or os.getenv("ETCD")
+    if etcd_url == nil then
+        local etcd_host = os.getenv("ETCD_HOST") or "127.0.0.1"
+        local etcd_port = os.getenv("ETCD_PORT") or "2379"
+        return "http://"..etcd_host..":"..etcd_port
+    end
+    return etcd_url
+end
+
 _M.NAME = os.getenv("ELBNAME") or 'ELB'
-_M.ETCD = os.getenv("ETCD") or 'http://127.0.0.1:2379'
+-- _M.ETCD = os.getenv("ETCD") or 'http://127.0.0.1:2379'
+_M.ETCD = get_etcd()
 _M.STATSD = os.getenv("STATSD")
 _M.STATSD_FORMAT = _M.NAME..'.%s.%s'
 


### PR DESCRIPTION
@timfeirg 因为之前太tm懒了直接写的 `ETCD`, 只好这样拆一下, 测试是需要 etcd 容器的呀... 做个 link 进去吧, 不然 dump 那部分不好测了...

然后我改掉了默认端口, surge 占用了 8888, 加多了个 1